### PR TITLE
Added a system to specify the project key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The action will set the "fix version" in Jira to the given version (and creates 
 - `versionDescription`: The description of the Version (default: "CD version")
 - `versionArchived`: Mark the new version as archived (default: `false`)
 - `versionReleased`: Mark the new version as released (default: `false`)
+- `projectKey`: The project the new version should be created in (default: project key of the first issue key)
 
 ## Outputs
 None

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   versionReleased:
     description: 'Mark the new version as released (default: false)'
     required: false
+  projectKey:
+    description: 'The project the new version should be created in (default: project key of the first issue key)'
+    required: false
 runs:
   using: 'node20'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -36,8 +36,10 @@ async function createAndSetVersion(projectKey, issueKeys, versionName, versionDe
     const issueKeyArr = issueKeys.split(",");
     for (let i = 0; i < issueKeyArr.length; i++) {
         const issueKey = issueKeyArr[i];
-        const issueId = await getIssueId(issueKey);
-        await setVersion(issueId, versionId);
+        if (issueKey) {
+            const issueId = await getIssueId(issueKey);
+            await setVersion(issueId, versionId);
+        }
     }
     // archive version (passing it as argument while creating version doesn't work
     if (versionArchived) {


### PR DESCRIPTION
Fixes #7 

Introduced an optional input `projectKey` that can be used to specify the project the version should be created in.